### PR TITLE
fix(fj-svelte): split out question component

### DIFF
--- a/clients/fj-svelte/src/lib/Client.svelte
+++ b/clients/fj-svelte/src/lib/Client.svelte
@@ -3,11 +3,10 @@
   import Popout from "./Popout.svelte";
   import Sidebar from "./Sidebar.svelte";
   import Scoreboard from "./Scoreboard.svelte";
-  import Question from "./Question.svelte";
+  import QuestionContents from "./QuestionContents.svelte";
   import {
     type QuestionMeta,
     selected_question,
-    difficulty_name,
   } from "../utils";
 
   import { get_username } from "../api";
@@ -60,7 +59,7 @@
     </div>
   </div>
   <Sidebar {questions} />
-  <Question question_data={questions[$selected_question]} {set_solved} />
+  <QuestionContents question_data={questions[$selected_question]} {set_solved} />
 </div>
 
 <Popout

--- a/clients/fj-svelte/src/lib/Client.svelte
+++ b/clients/fj-svelte/src/lib/Client.svelte
@@ -31,16 +31,6 @@
   }
 
   let showing_popout: ShowingPopout = ShowingPopout.None;
-
-  let question_instructions: any;
-
-  selected_question.subscribe((slug) => {
-    if (slug === undefined) return;
-
-    if (question_instructions !== undefined) {
-      question_instructions.scrollTop = 0;
-    }
-  });
 </script>
 
 <div class="layout">

--- a/clients/fj-svelte/src/lib/Client.svelte
+++ b/clients/fj-svelte/src/lib/Client.svelte
@@ -3,7 +3,7 @@
   import Popout from "./Popout.svelte";
   import Sidebar from "./Sidebar.svelte";
   import Scoreboard from "./Scoreboard.svelte";
-  import SubmissionArea from "./SubmissionArea.svelte";
+  import Question from "./Question.svelte";
   import {
     type QuestionMeta,
     selected_question,
@@ -60,45 +60,7 @@
     </div>
   </div>
   <Sidebar {questions} />
-  <div
-    id="question-instructions"
-    class="question-instructions"
-    bind:this={question_instructions}
-  >
-    {#if $selected_question !== undefined}
-      {#if questions[$selected_question] !== undefined}
-        <h1 style="margin-top: 0px;">
-          <span
-            style={questions[$selected_question].solved
-              ? "text-decoration: line-through;"
-              : ""}
-          >
-            {questions[$selected_question].name}
-          </span>
-
-          {#if questions[$selected_question].solved}
-            <span style="font-size: 1.3rem;">✓</span>
-          {/if}
-        </h1>
-
-        <div style="margin-left: 1rem;">
-          <span style="margin-right: 1rem; opacity:0.7;"
-            ><b>Difficulty:</b>
-            {difficulty_name(questions[$selected_question].difficulty)}</span
-          >
-          <span style="opacity:0.7;"
-            ><b>Points:</b> {questions[$selected_question].points}</span
-          >
-        </div>
-
-        <div id="instructions-md">
-          {@html questions[$selected_question].instructions}
-        </div>
-      {/if}
-
-      <SubmissionArea {set_solved} />
-    {/if}
-  </div>
+  <Question question_data={questions[$selected_question]} {set_solved} />
 </div>
 
 <Popout
@@ -141,13 +103,5 @@
     padding: 0.25rem;
     color: var(--text-sec);
     background-color: var(--bg-sec);
-  }
-
-  .question-instructions {
-    color: var(--text-prim);
-    grid-area: question-instructions;
-    overflow-y: scroll;
-    padding: 1rem;
-    text-wrap: pretty;
   }
 </style>

--- a/clients/fj-svelte/src/lib/Question.svelte
+++ b/clients/fj-svelte/src/lib/Question.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import SubmissionArea from "./SubmissionArea.svelte";
+  import {
+    type QuestionMeta,
+    selected_question,
+    difficulty_name,
+  } from "../utils";
+
+  export let question_data: QuestionMeta | undefined = undefined;
+  export let set_solved: (slug: string) => void;
+
+  let question_instructions: any;
+
+  // Reset scroll to top when a new question is selected
+  selected_question.subscribe((slug) => {
+    if (slug === undefined) return;
+
+    if (question_instructions !== undefined) {
+      question_instructions.scrollTop = 0; // huh?
+    }
+  });
+</script>
+
+<div class="question">
+  <div
+    id="question-instructions"
+    class="question-instructions"
+    bind:this={question_instructions}
+  >
+    {#if $selected_question !== undefined}
+      {#if question_data !== undefined}
+        <h1 style="margin-top: 0px;">
+          <span
+            style={question_data.solved
+              ? "text-decoration: line-through;"
+              : ""}
+          >
+            {question_data.name}
+          </span>
+
+          {#if question_data.solved}
+            <span style="font-size: 1.3rem;">✓</span>
+          {/if}
+        </h1>
+
+        <div style="margin-left: 1rem;">
+          <span style="margin-right: 1rem; opacity:0.7;"
+            ><b>Difficulty:</b>
+            {difficulty_name(question_data.difficulty)}</span
+          >
+          <span style="opacity:0.7;"
+            ><b>Points:</b> {question_data.points}</span
+          >
+        </div>
+
+        <div id="instructions-md">
+          {@html question_data.instructions}
+        </div>
+      {/if}
+
+      <SubmissionArea {set_solved} />
+    {/if}
+  </div>
+</div>
+
+<style>
+  .question-instructions {
+    color: var(--text-prim);
+    grid-area: question-instructions;
+    overflow-y: scroll;
+    padding: 1rem;
+    text-wrap: pretty;
+  }
+</style>

--- a/clients/fj-svelte/src/lib/QuestionContents.svelte
+++ b/clients/fj-svelte/src/lib/QuestionContents.svelte
@@ -16,7 +16,7 @@
     if (slug === undefined) return;
 
     if (question_instructions !== undefined) {
-      question_instructions.scrollTop = 0; // huh?
+      question_instructions.scrollTop = 0;
     }
   });
 </script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,9 +39,9 @@ Backend
 
 */
 
-import { undent, indent, loadMarkdown } from "./util.ts";
+import { loadMarkdown } from "./util.ts";
 import { FuzzJudgeProblem } from "./comp.ts";
-import { pathJoin, walk, serveFile, normalize, WebSocketServer, WebSocketClient } from "./deps.ts";
+import { pathJoin, walk, serveFile, normalize, WebSocketServer } from "./deps.ts";
 import { Auth } from "./auth.ts";
 import { appendAnswer, getScoreboard, getAnswered, initialiseUserScore, subscribeToScoreboard, createScoreboardCSV } from "./score.ts";
 import { Router } from "./http.ts";


### PR DESCRIPTION
This is in preparation to later change the Client component to show a new Countdown component instead of Question before/after the correct time (which it will get with a call to the backend). I will also change the sidebar component to say something like 'questions will be here' and then finally will protect the sensitive api calls outside the competition time.

Before the competition starts, when it is showing a start time/countdown, I though it would be good to still use the same page layout and allow access to the 'comp info' popup so that users can get familiar and know what to expect.
