### PR TITLE
feat(clients/fj-svelte): Add countdown component

### DIFF
--- a/clients/fj-svelte/src/App.svelte
+++ b/clients/fj-svelte/src/App.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
   import Client from "./lib/Client.svelte";
   import Loading from "./lib/Loading.svelte";
-  import { CompState, get_current_comp_state, get_time_till_next_state, needs_questions, type CompTimes, type QuestionMeta } from "./utils";
+  import {
+    CompState,
+    get_current_comp_state,
+    get_time_till_next_state,
+    needs_questions,
+    type CompTimes,
+    type QuestionMeta,
+  } from "./utils";
   import { get_questions, get_comp_info, get_comp_times } from "./api";
   import { onDestroy } from "svelte";
 
@@ -15,44 +22,51 @@
 
   const load_questions = () => {
     get_questions()
-    .then((q) => {
-      questions = q;
-    })
-    .catch((err) => {
-      loading_error = err;
-    });
-  }
+      .then((q) => {
+        questions = q;
+      })
+      .catch((err) => {
+        loading_error = err;
+      });
+  };
 
   let current_state: CompState | undefined = undefined;
   let timer_ref = -1;
   // Sets a timer to trigger a rerender to update the main content
   const set_timer_for_next_state = () => {
-    if(comp_times == undefined) return;
+    if (comp_times == undefined) return;
     current_state = get_current_comp_state(comp_times);
-    if(needs_questions(comp_times)) {
+    if (needs_questions(comp_times)) {
       load_questions();
     }
     console.log(`changed current state to ${current_state}`);
 
-    timer_ref = setTimeout(() => {
-      set_timer_for_next_state();
-    }, get_time_till_next_state(comp_times, current_state));
+    timer_ref = setTimeout(
+      () => {
+        set_timer_for_next_state();
+      },
+      get_time_till_next_state(comp_times, current_state),
+    );
   };
-  onDestroy(() => clearTimeout(timer_ref))
-  
-  
-  get_comp_times().then(t => {
-    console.log("got times");
-    comp_times = t;
-    if(needs_questions(t)) {
-      load_questions();
-    }
-    set_timer_for_next_state();
-  })
-  .catch((err) => {
-    loading_error = err
-  });
+  onDestroy(() => clearTimeout(timer_ref));
 
+  get_comp_times()
+    .then((t) => {
+      if (t === undefined) {
+        load_questions();
+        return;
+      }
+
+      console.log("got times");
+      comp_times = t;
+      if (needs_questions(t)) {
+        load_questions();
+      }
+      set_timer_for_next_state();
+    })
+    .catch((err) => {
+      loading_error = err;
+    });
 
   const set_solved = (slug: string) => {
     if (questions === undefined) return;
@@ -71,7 +85,7 @@
   }
 </script>
 
-{#if comp_times !== undefined && current_state !== undefined && (!needs_questions(comp_times) || questions !== undefined)}
+{#if ((comp_times !== undefined && !needs_questions(comp_times)) || questions !== undefined)}
   <Client {questions} {set_solved} {comp_times} {current_state} />
 {:else if loading_error !== undefined}
   <div class="loading">Error loading questions: {loading_error}</div>

--- a/clients/fj-svelte/src/App.svelte
+++ b/clients/fj-svelte/src/App.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import Client from "./lib/Client.svelte";
   import Loading from "./lib/Loading.svelte";
-  import { needs_questions, type CompTimes, type QuestionMeta } from "./utils";
+  import { CompState, get_current_comp_state, get_time_till_next_state, needs_questions, type CompTimes, type QuestionMeta } from "./utils";
 
   import { get_questions, get_comp_info, get_comp_times } from "./api";
+    import { onDestroy } from "svelte";
 
   let comp_times: CompTimes | undefined = undefined;
   let questions: Record<string, QuestionMeta> | undefined = undefined;
@@ -23,15 +24,36 @@
     });
   }
 
+  let current_state: CompState | undefined = undefined;
+  let timer_ref = -1;
+  // Sets a timer to trigger a rerender to update the main content
+  const set_timer_for_next_state = () => {
+    if(comp_times == undefined) return;
+    current_state = get_current_comp_state(comp_times);
+    if(needs_questions(comp_times)) {
+      load_questions();
+    }
+    console.log(`changed current state to ${current_state}`);
+
+    timer_ref = setTimeout(() => {
+      set_timer_for_next_state();
+    }, get_time_till_next_state(comp_times, current_state));
+  };
+  onDestroy(() => clearTimeout(timer_ref))
+  
+  
   get_comp_times().then(t => {
-    comp_times = t
+    console.log("got times");
+    comp_times = t;
     if(needs_questions(t)) {
       load_questions();
     }
+    set_timer_for_next_state();
   })
   .catch((err) => {
     loading_error = err
   });
+
 
   const set_solved = (slug: string) => {
     if (questions === undefined) return;
@@ -50,8 +72,8 @@
   }
 </script>
 
-{#if comp_times !== undefined && (!needs_questions(comp_times) || questions !== undefined)}
-  <Client {questions} {set_solved} {comp_times} />
+{#if comp_times !== undefined && current_state !== undefined && (!needs_questions(comp_times) || questions !== undefined)}
+  <Client {questions} {set_solved} {comp_times} {current_state} />
 {:else if loading_error !== undefined}
   <div class="loading">Error loading questions: {loading_error}</div>
 {:else}

--- a/clients/fj-svelte/src/App.svelte
+++ b/clients/fj-svelte/src/App.svelte
@@ -2,9 +2,8 @@
   import Client from "./lib/Client.svelte";
   import Loading from "./lib/Loading.svelte";
   import { CompState, get_current_comp_state, get_time_till_next_state, needs_questions, type CompTimes, type QuestionMeta } from "./utils";
-
   import { get_questions, get_comp_info, get_comp_times } from "./api";
-    import { onDestroy } from "svelte";
+  import { onDestroy } from "svelte";
 
   let comp_times: CompTimes | undefined = undefined;
   let questions: Record<string, QuestionMeta> | undefined = undefined;

--- a/clients/fj-svelte/src/App.svelte
+++ b/clients/fj-svelte/src/App.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import Client from "./lib/Client.svelte";
   import Loading from "./lib/Loading.svelte";
-  import { type QuestionMeta } from "./utils";
+  import { needs_questions, type CompTimes, type QuestionMeta } from "./utils";
 
-  import { get_questions, get_comp_info } from "./api";
+  import { get_questions, get_comp_info, get_comp_times } from "./api";
 
+  let comp_times: CompTimes | undefined = undefined;
   let questions: Record<string, QuestionMeta> | undefined = undefined;
   let loading_error: string | undefined = undefined;
 
@@ -12,13 +13,25 @@
     window.document.title = data.title;
   });
 
-  get_questions()
+  const load_questions = () => {
+    get_questions()
     .then((q) => {
       questions = q;
     })
     .catch((err) => {
       loading_error = err;
     });
+  }
+
+  get_comp_times().then(t => {
+    comp_times = t
+    if(needs_questions(t)) {
+      load_questions();
+    }
+  })
+  .catch((err) => {
+    loading_error = err
+  });
 
   const set_solved = (slug: string) => {
     if (questions === undefined) return;
@@ -37,8 +50,8 @@
   }
 </script>
 
-{#if questions !== undefined}
-  <Client {questions} {set_solved} />
+{#if comp_times !== undefined && (!needs_questions(comp_times) || questions !== undefined)}
+  <Client {questions} {set_solved} {comp_times} />
 {:else if loading_error !== undefined}
   <div class="loading">Error loading questions: {loading_error}</div>
 {:else}

--- a/clients/fj-svelte/src/api.ts
+++ b/clients/fj-svelte/src/api.ts
@@ -109,8 +109,10 @@ const get_question_data = async (slug: string) => {
   return data;
 };
 
-export const get_comp_times = async (): Promise<CompTimes> => {
-  return new Promise((resolve, _) => {
-    resolve(parse_times("dummy data to get from request"));
-  });
+export const get_comp_times = async (): Promise<CompTimes | undefined> => {
+  return undefined;
+
+  // return new Promise((resolve, _) => {
+  //   resolve(parse_times("dummy data to get from request"));
+  // });
 }

--- a/clients/fj-svelte/src/api.ts
+++ b/clients/fj-svelte/src/api.ts
@@ -1,4 +1,4 @@
-import { BACKEND_SERVER, parse_scoreboard, question_order, type QuestionMeta, type ScoreboardUser} from "./utils";
+import { BACKEND_SERVER, parse_scoreboard, parse_times, question_order, type CompTimes, type QuestionMeta, type ScoreboardUser} from "./utils";
 
 export let get_questions = async (): Promise<Record<string, QuestionMeta>> => {
   let questions: Record<string, QuestionMeta> = {};
@@ -109,3 +109,8 @@ const get_question_data = async (slug: string) => {
   return data;
 };
 
+export const get_comp_times = async (): Promise<CompTimes> => {
+  return new Promise((resolve, _) => {
+    resolve(parse_times("dummy data to get from request"));
+  });
+}

--- a/clients/fj-svelte/src/lib/Client.svelte
+++ b/clients/fj-svelte/src/lib/Client.svelte
@@ -8,15 +8,11 @@
     type QuestionMeta,
     selected_question,
     type CompTimes,
-    needs_questions,
     CompState,
-    get_current_comp_state,
-    get_time_till_next_state,
   } from "../utils";
 
   import { get_username } from "../api";
-    import Countdown from "./Countdown.svelte";
-    import { onDestroy } from "svelte";
+  import Countdown from "./Countdown.svelte";
 
   let username = "Loading...";
 
@@ -25,21 +21,9 @@
   });
 
   export let comp_times: CompTimes;
+  export let current_state: CompState; // can be infered from comp_times but is passed in to make it reactive
   export let questions: Record<string, QuestionMeta> = {};
   export let set_solved: (slug: string) => void;
-
-  let current_state = get_current_comp_state(comp_times);
-  let timer_ref = -1;
-  // Sets a timer to trigger a rerender to update the main content
-  const set_timer_for_next_state = () => {
-    timer_ref = setTimeout(() => {
-      current_state = get_current_comp_state(comp_times);
-      console.log(`changed current state to ${current_state}`);
-      set_timer_for_next_state();
-    }, get_time_till_next_state(comp_times, current_state));
-  };
-  set_timer_for_next_state();
-  onDestroy(() => clearTimeout(timer_ref))
 
   selected_question.set(
     Object.values(questions).find((q) => q.num === 1)?.slug ?? "",
@@ -63,12 +47,16 @@
       <button on:click={() => (showing_popout = ShowingPopout.Scoreboard)}
         >Scoreboard</button
       >
+      {#if current_state === CompState.LIVE_WITH_SCORES || current_state === CompState.LIVE_WITHOUT_SCORES }
+        <span>Remaining: <Countdown {comp_times} until_state={CompState.FINISHED} show_binary={false}/></span>
+      {/if}
     </div>
     <div>
       Logged in as <b>{username}</b>
       <a href="/auth/logout">Logout</a>
     </div>
   </div>
+
   <Sidebar {questions} />
 
   <!-- main content -->

--- a/clients/fj-svelte/src/lib/Client.svelte
+++ b/clients/fj-svelte/src/lib/Client.svelte
@@ -47,8 +47,14 @@
       <button on:click={() => (showing_popout = ShowingPopout.Scoreboard)}
         >Scoreboard</button
       >
-      {#if current_state === CompState.LIVE_WITH_SCORES || current_state === CompState.LIVE_WITHOUT_SCORES }
-        <span>Remaining: <Countdown {comp_times} until_state={CompState.FINISHED} show_binary={false}/></span>
+      {#if current_state === CompState.LIVE_WITH_SCORES || current_state === CompState.LIVE_WITHOUT_SCORES}
+        <span
+          >Remaining: <Countdown
+            {comp_times}
+            until_state={CompState.FINISHED}
+            show_binary={false}
+          /></span
+        >
       {/if}
     </div>
     <div>
@@ -61,13 +67,19 @@
 
   <!-- main content -->
   {#if current_state === CompState.LIVE_WITH_SCORES || current_state === CompState.LIVE_WITHOUT_SCORES}
-    <QuestionContents question_data={questions[$selected_question]} {set_solved} />
+    <QuestionContents
+      question_data={questions[$selected_question]}
+      {set_solved}
+    />
   {:else if current_state == CompState.BEFORE}
-    <Countdown {comp_times} until_state={CompState.LIVE_WITH_SCORES} />
+    <div class="locked-message">
+      <Countdown {comp_times} until_state={CompState.LIVE_WITH_SCORES} />
+    </div>
   {:else}
-    <h1>Finished</h1>
+    <div class="locked-message">
+      <h1>Finished</h1>
+    </div>
   {/if}
-
 </div>
 
 <Popout
@@ -110,5 +122,15 @@
     padding: 0.25rem;
     color: var(--text-sec);
     background-color: var(--bg-sec);
+  }
+
+  .locked-message {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    width: 100%;
+    font-size: 1.5rem;
+    color: var(--text-sec);
   }
 </style>

--- a/clients/fj-svelte/src/lib/Client.svelte
+++ b/clients/fj-svelte/src/lib/Client.svelte
@@ -7,9 +7,14 @@
   import {
     type QuestionMeta,
     selected_question,
+    type CompTimes,
+    needs_questions,
+    CompState,
+    get_current_comp_state,
   } from "../utils";
 
   import { get_username } from "../api";
+    import Countdown from "./Countdown.svelte";
 
   let username = "Loading...";
 
@@ -17,6 +22,7 @@
     username = name;
   });
 
+  export let comp_times: CompTimes;
   export let questions: Record<string, QuestionMeta> = {};
   export let set_solved: (slug: string) => void;
 
@@ -49,7 +55,16 @@
     </div>
   </div>
   <Sidebar {questions} />
-  <QuestionContents question_data={questions[$selected_question]} {set_solved} />
+
+  <!-- main content -->
+  {#if needs_questions(comp_times)}
+    <QuestionContents question_data={questions[$selected_question]} {set_solved} />
+  {:else if get_current_comp_state(comp_times) == CompState.BEFORE}
+    <Countdown {comp_times} until_state={CompState.LIVE_WITH_SCORES} />
+  {:else}
+    <h1>Finished</h1>
+  {/if}
+
 </div>
 
 <Popout

--- a/clients/fj-svelte/src/lib/Client.svelte
+++ b/clients/fj-svelte/src/lib/Client.svelte
@@ -20,12 +20,12 @@
     username = name;
   });
 
-  export let comp_times: CompTimes;
-  export let current_state: CompState; // can be infered from comp_times but is passed in to make it reactive
+  export let comp_times: CompTimes | undefined = undefined;
+  export let current_state: CompState | undefined = undefined; // can be infered from comp_times but is passed in to make it reactive
   export let questions: Record<string, QuestionMeta> = {};
   export let set_solved: (slug: string) => void;
 
-  selected_question.set(
+  $: selected_question.set(
     Object.values(questions).find((q) => q.num === 1)?.slug ?? "",
   );
 
@@ -47,7 +47,7 @@
       <button on:click={() => (showing_popout = ShowingPopout.Scoreboard)}
         >Scoreboard</button
       >
-      {#if current_state === CompState.LIVE_WITH_SCORES || current_state === CompState.LIVE_WITHOUT_SCORES}
+      {#if comp_times !== undefined && (current_state === CompState.LIVE_WITH_SCORES || current_state === CompState.LIVE_WITHOUT_SCORES)}
         <span
           >Remaining: <Countdown
             {comp_times}
@@ -66,7 +66,7 @@
   <Sidebar {questions} />
 
   <!-- main content -->
-  {#if current_state === CompState.LIVE_WITH_SCORES || current_state === CompState.LIVE_WITHOUT_SCORES}
+  {#if comp_times === undefined || (current_state === CompState.LIVE_WITH_SCORES || current_state === CompState.LIVE_WITHOUT_SCORES)}
     <QuestionContents
       question_data={questions[$selected_question]}
       {set_solved}

--- a/clients/fj-svelte/src/lib/Countdown.svelte
+++ b/clients/fj-svelte/src/lib/Countdown.svelte
@@ -1,26 +1,34 @@
 <script lang="ts">
-    import { onDestroy } from "svelte";
-    import { get_state_start_time, type CompState, type CompTimes } from "../utils";
+  import { onDestroy } from "svelte";
+  import {
+    get_state_start_time,
+    type CompState,
+    type CompTimes,
+  } from "../utils";
 
   export let comp_times: CompTimes;
   export let until_state: CompState;
   export let show_binary: boolean = true;
   export let show_decimal: boolean = true;
 
-  const start_time = get_state_start_time(comp_times, until_state)
+  const start_time = get_state_start_time(comp_times, until_state);
 
-  let time_left_bin = ""
+  let time_left_bin = "";
   let time_left_dec = "";
 
   let anim_frame_ref: number;
   (function update() {
-    anim_frame_ref = requestAnimationFrame(update)
+    anim_frame_ref = requestAnimationFrame(update);
     const now = new Date(Date.now());
-    const seconds_till: number = Math.floor((start_time.getTime() - now.getTime()) / 1000);
+    const seconds_till: number = Math.floor(
+      (start_time.getTime() - now.getTime()) / 1000,
+    );
 
     time_left_bin = seconds_till.toString(2).padStart(10, "0");
 
-    const mins = Math.floor(seconds_till / 60).toString().padStart(2, "0");
+    const mins = Math.floor(seconds_till / 60)
+      .toString()
+      .padStart(2, "0");
     const secs = (seconds_till % 60).toString().padStart(2, "0");
     time_left_dec = `${mins}:${secs}`;
   })();
@@ -28,7 +36,6 @@
   onDestroy(() => {
     cancelAnimationFrame(anim_frame_ref);
   });
-
 </script>
 
 <span>

--- a/clients/fj-svelte/src/lib/Countdown.svelte
+++ b/clients/fj-svelte/src/lib/Countdown.svelte
@@ -4,6 +4,8 @@
 
   export let comp_times: CompTimes;
   export let until_state: CompState;
+  export let show_binary: boolean = true;
+  export let show_decimal: boolean = true;
 
   const start_time = get_state_start_time(comp_times, until_state)
 
@@ -29,10 +31,14 @@
 
 </script>
 
-<div>
-  {time_left_bin}
-  {time_left_dec}
-</div>
+<span>
+  {#if show_binary}
+    {time_left_bin}
+  {/if}
+  {#if show_decimal}
+    {time_left_dec}
+  {/if}
+</span>
 
 <style>
 </style>

--- a/clients/fj-svelte/src/lib/Countdown.svelte
+++ b/clients/fj-svelte/src/lib/Countdown.svelte
@@ -26,8 +26,8 @@
   })();
 
   onDestroy(() => {
-		cancelAnimationFrame(anim_frame_ref);
-	});
+    cancelAnimationFrame(anim_frame_ref);
+  });
 
 </script>
 

--- a/clients/fj-svelte/src/lib/Countdown.svelte
+++ b/clients/fj-svelte/src/lib/Countdown.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+    import { onDestroy } from "svelte";
+    import { get_state_start_time, type CompState, type CompTimes } from "../utils";
+
+  export let comp_times: CompTimes;
+  export let until_state: CompState;
+
+  const start_time = get_state_start_time(comp_times, until_state)
+
+  let time_left_bin = ""
+  let time_left_dec = "";
+
+  let anim_frame_ref: number;
+  (function update() {
+    anim_frame_ref = requestAnimationFrame(update)
+    const now = new Date(Date.now());
+    const seconds_till: number = Math.floor((start_time.getTime() - now.getTime()) / 1000);
+
+    time_left_bin = seconds_till.toString(2).padStart(10, "0");
+
+    const mins = Math.floor(seconds_till / 60).toString().padStart(2, "0");
+    const secs = (seconds_till % 60).toString().padStart(2, "0");
+    time_left_dec = `${mins}:${secs}`;
+  })();
+
+  onDestroy(() => {
+		cancelAnimationFrame(anim_frame_ref);
+	});
+
+</script>
+
+<div>
+  {time_left_bin}
+  {time_left_dec}
+</div>
+
+<style>
+</style>

--- a/clients/fj-svelte/src/utils.ts
+++ b/clients/fj-svelte/src/utils.ts
@@ -88,3 +88,47 @@ export const parse_scoreboard = (data: string): ScoreboardUser[] => {
   return users;
 };
 
+
+export interface CompTimes {
+  start: Date,
+  freeze: Date,
+  stop: Date,
+}
+
+export const parse_times = (data: string): CompTimes => {
+  return { start: new Date(Date.now() + 10000), freeze: new Date(Date.now() + 20000), stop: new Date(Date.now() + 30000)};
+}
+
+export enum CompState {
+  BEFORE, LIVE_WITH_SCORES, LIVE_WITHOUT_SCORES, FINISHED
+}
+
+export const get_current_comp_state = (times: CompTimes) => {
+  const now = new Date(Date.now());
+  if(now < times.start) {
+    return CompState.BEFORE;
+  } else if (now < times.freeze) {
+    return CompState.LIVE_WITH_SCORES;
+  } else if (now < times.stop) {
+    return CompState.LIVE_WITHOUT_SCORES;
+  } else {
+    return CompState.FINISHED;
+  }
+}
+
+export const get_state_start_time = (times: CompTimes, state: CompState): Date => {
+  switch (state) {
+    case CompState.LIVE_WITH_SCORES:
+    case CompState.BEFORE: // theres not really a start time for before so it is just the start time of live
+      return times.start;
+    case CompState.LIVE_WITHOUT_SCORES:
+      return times.freeze;
+    case CompState.FINISHED:
+      return times.stop;
+  }
+}
+
+export const needs_questions = (times: CompTimes): boolean => {
+  const state = get_current_comp_state(times)
+  return state === CompState.LIVE_WITH_SCORES || state === CompState.LIVE_WITHOUT_SCORES
+}

--- a/clients/fj-svelte/src/utils.ts
+++ b/clients/fj-svelte/src/utils.ts
@@ -129,8 +129,8 @@ export const get_state_start_time = (times: CompTimes, state: CompState): Date =
 }
 
 // Returns the number of milliseconds until the next state
-export const get_time_till_next_state = (times: CompTimes, current: CompState): number => {
-  if(current === CompState.FINISHED) {
+export const get_time_till_next_state = (times: CompTimes | undefined, current: CompState | undefined): number => {
+  if(current === CompState.FINISHED || times == undefined || current == undefined) {
     return 1e10;
   }
 

--- a/clients/fj-svelte/src/utils.ts
+++ b/clients/fj-svelte/src/utils.ts
@@ -96,7 +96,7 @@ export interface CompTimes {
 }
 
 export const parse_times = (data: string): CompTimes => {
-  return { start: new Date(Date.now() + 10000), freeze: new Date(Date.now() + 20000), stop: new Date(Date.now() + 30000)};
+  return { start: new Date(Date.now() + 5000), freeze: new Date(Date.now() + 20000), stop: new Date(Date.now() + 30000)};
 }
 
 export enum CompState {
@@ -126,6 +126,15 @@ export const get_state_start_time = (times: CompTimes, state: CompState): Date =
     case CompState.FINISHED:
       return times.stop;
   }
+}
+
+// Returns the number of milliseconds until the next state
+export const get_time_till_next_state = (times: CompTimes, current: CompState): number => {
+  if(current === CompState.FINISHED) {
+    return 1e10;
+  }
+
+  return get_state_start_time(times, current + 1).getTime() - new Date().getTime();
 }
 
 export const needs_questions = (times: CompTimes): boolean => {


### PR DESCRIPTION
Add a countdown component that can be used: before the comp, during the comp in the top bar and in the scoreboard before the freeze. Also added the state and stubbed request to get the times from the backend.