### PR TITLE
Add deno lock to gitignore temporarily

### DIFF
--- a/clients/fj-svelte/.gitignore
+++ b/clients/fj-svelte/.gitignore
@@ -24,3 +24,6 @@ dist-ssr
 *.sw?
 
 public/*.json
+
+# Remove this later when we get a better grasp on how deno is managed
+deno.lock


### PR DESCRIPTION
Add deno lock to gitignore temporarily

We can always remove it later. I don't think the deno lock is supposed to be in the ui folder though, but we don't have time for that atm
