### PR TITLE
hotfix: comp.md escape dollar signs for latex

### DIFF
--- a/sample/comp.md
+++ b/sample/comp.md
@@ -42,4 +42,4 @@ There are 2 points systems:
 
 ## Prizes
 
-1st place: $1500 2nd place: $900 3rd place: $600
+1st place: \$1500 2nd place: \$900 3rd place: \$600


### PR DESCRIPTION
hotfix: comp.md escape dollar signs for latex

Not sure if a dollar sign with a space before it should be recognised as a latex closing tag, but simple fix for now
