### PR TITLE
Allow for easily creating endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # .vscode/
 *.db
-sample/client/
 competition/
 node_modules/
 dist

--- a/sample/client/index.html
+++ b/sample/client/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/markdown.js/0.5.0/markdown.min.js" integrity="sha512-kaDP6dcDG3+X87m9SnhyJzwBMKrYnd2tLJjGdBrZ9yEL8Zcl2iJRsPwylLkbd2g3QC5S8efV3sgwI5r73U0HnA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+</head>
+
+<div id="problem-list"></div>
+<h1 id="problem-title"></h1>
+<div id="problem-instructions"></div>
+
+<form id="submission-area" method="post">
+	<label for="Solution">Solution:</label><br>
+	<textarea type="text" name="output"></textarea><br>
+	<label for="Solution">Source:</label><br>
+	<textarea type="text" name="source" placeholder="Code used to solve problem. May be reveiwed later."></textarea><br>
+	<input type="submit" id="submit">
+</form>
+
+<script>
+	const compName = document.getElementById("comp-name");
+	const problemList = document.getElementById("problem-list");
+	const problemTitle = document.getElementById("problem-title");
+	const instructions = document.getElementById("problem-instructions");
+	const submissionArea = document.getElementById("submission-area");
+
+	async function showProblem(slug) {
+		const title = await (await fetch(`/comp/prob/${slug}/name`)).text();
+		problemTitle.innerText = title;
+
+		const md = await (await fetch(`/comp/prob/${slug}/instructions`)).text();
+
+		instructions.innerHTML = markdown.toHTML(md);
+
+		const fuzzLink = document.createElement("a");
+		fuzzLink.innerText = "Get problem input!";
+		fuzzLink.href = `/comp/prob/${slug}/fuzz`;
+		fuzzLink.target = "_blank";
+		instructions.appendChild(fuzzLink);
+
+		submissionArea.action = `/comp/prob/${slug}/judge`;
+	}
+
+	fetch("/comp/prob")
+		.then((response) => response.text())
+		.then((text) => {
+			for (const problem of text.split(",")) {
+				const problemElement = document.createElement("a");
+				problemElement.innerText = problem;
+				problemElement.onclick = () => showProblem(problem); 
+				problemElement.href = "#";
+				problemList.appendChild(problemElement);
+			}
+		})
+</script>
+</html>

--- a/sample/comp.md
+++ b/sample/comp.md
@@ -1,6 +1,5 @@
 ---toml
 [server]
-origins = ["*"]
 public = ["client"]
 
 [times]

--- a/sample/comp.md
+++ b/sample/comp.md
@@ -1,4 +1,8 @@
 ---toml
+[server]
+origins = ["*"]
+public = ["client"]
+
 [times]
 start = "2024-06-24T11:30:00+1000"
 finish = "2025-06-24T03:30:00+1000"

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -27,12 +27,12 @@ Backend
 - /instructions
 - /prob
   - /:name
-    - /icon : utf-8 (emoji, one extended grapheme)
-    - /name
-    - /brief
-    - /instructions
-    - /input
-    - /judge
+	- /icon : utf-8 (emoji, one extended grapheme)
+	- /name
+	- /brief
+	- /instructions
+	- /input
+	- /judge
 /auth
 - /login : Get Bearer Token
 - /logout : Expire token
@@ -364,7 +364,6 @@ const app = new OpenAPIHono()
 			return c.body(null, { status: 204 });
 		},
 	)
-
 	.openapi(
 		createRoute({
 			method: "get",
@@ -390,26 +389,19 @@ const app = new OpenAPIHono()
 		async (c) => {
 			return c.body(null, { status: 204 });
 		},
-	)
-	.openapi(
-		createRoute({
-			method: "get",
-			path: "/client/*",
-			hide: true,
-			responses: {
-				200: {
-					description: "Client",
-				},
-			},
-			middleware: serveStatic({
-				root: path.join(root, "client"),
-			}),
-			operationId: "getClient",
-		}),
-		async (c) => {
-			return c.text("dummy response");
-		},
 	);
+
+for (const dir of competionData.server?.public ?? []) {
+	const relativeDirPath = path.relative(process.cwd(), root);
+	app.get(
+		`/${dir}/*`,
+		serveStatic({
+			root: relativeDirPath,
+			onNotFound: (path, c) =>
+				console.error(`${path} is not found for ${c.req.path}`),
+		}),
+	);
+}
 
 app.doc31("/docs/json", (c) => ({
 	info: {

--- a/server/src/services/competition.service.ts
+++ b/server/src/services/competition.service.ts
@@ -5,6 +5,12 @@ import matter from "gray-matter";
 import { parseMarkdownAttributes } from "./problems.service";
 
 const competitionSpec = z.object({
+	server: z
+		.object({
+			origins: z.array(z.string()).optional(),
+			public: z.array(z.string()).optional(),
+		})
+		.optional(),
 	times: z.object({
 		start: z.coerce.date().optional(),
 		finish: z.coerce.date().optional(),

--- a/server/src/services/competition.service.ts
+++ b/server/src/services/competition.service.ts
@@ -7,7 +7,7 @@ import { parseMarkdownAttributes } from "./problems.service";
 const competitionSpec = z.object({
 	server: z
 		.object({
-			origins: z.array(z.string()).optional(),
+			// origins: z.array(z.string()).optional(),
 			public: z.array(z.string()).optional(),
 		})
 		.optional(),


### PR DESCRIPTION
The `/client/` endpoint was just added as a temporary solution for ProgComp 2024. With this a competition organiser just has to add:
```
[server]
public = ["client"]
```
to `comp.md` and then `comp/client` is public on the `client` endpoint same as before except this is more flexible.
Another idea I had was maybe prefixing directories with an `@` or something to distinguish them from the problems but that's probably less intuitive.